### PR TITLE
Include charges != 1

### DIFF
--- a/peptide_fragmentor/peptide_fragmentor.py
+++ b/peptide_fragmentor/peptide_fragmentor.py
@@ -3,8 +3,8 @@ from itertools import combinations
 from collections import defaultdict as ddict
 import pandas as pd
 import numpy as np
-import pyqms
-from pyqms.chemical_composition import ChemicalComposition
+import ursgal
+from ursgal.chemical_composition import ChemicalComposition
 import copy
 import pprint
 
@@ -32,7 +32,8 @@ class PeptideFragment0r:
         if neutral_losses is None:
             neutral_losses = peptide_fragmentor.neutral_losses
         else:
-            neutral_losses += peptide_fragmentor.neutral_losses
+            # neutral_losses += peptide_fragmentor.neutral_losses
+            neutral_losses.update(peptide_fragmentor.neutral_losses)
         self.neutral_losses = neutral_losses
 
         if ions is None:
@@ -151,7 +152,7 @@ class PeptideFragment0r:
                         translated_peptide_pos, ''
                     )
                     for required_unimod in required_unimods:
-                        if required_unimod == uni_mod_at_pos:
+                        if required_unimod in uni_mod_at_pos:
                             neutral_loss_can_occure = True
 
                 if neutral_loss_can_occure is False:
@@ -176,19 +177,24 @@ class PeptideFragment0r:
                         new_ion_frag['cc'] += neutral_loss_dict.get('cc', {})
                         mod = neutral_loss_dict.get('name', None)
                         if mod is not None:
+                            if mod.replace('+', '-') in new_ion_frag['mods'] or\
+                                mod.replace('-', '+') in new_ion_frag['mods']:
+                                continue
                             new_ion_frag['mods'].append(mod)
                         new_ion_frag['hill'] = new_ion_frag['cc'].hill_notation_unimod()
-                        new_ion_frag['charge'] = 1
                         new_ion_frag['predicted intensity'] = np.NAN
                         new_ion_frag['mass'] = new_ion_frag['cc']._mass()
-                        new_ion_frag['mz'] = new_ion_frag['mass'] + peptide_fragmentor.PROTON
                         new_ion_frag['series'] = ion_type
                         new_ion_frag['modstring'] = ','.join(sorted(new_ion_frag['mods']))
                         new_ion_frag['seq'] += aa
                         new_ion_frag['name'] = new_ion_frag['name_format_string'].format(**new_ion_frag)
                         _id = '{name}{modstring}'.format(**new_ion_frag)
                         if _id not in alread_seen_frags:
-                            pos_dict['pos{0}'.format(dpos+1)][ion_type].append(new_ion_frag)
+                            for charge in self.charges:
+                                c_new_ion_frag = copy.deepcopy(new_ion_frag)
+                                c_new_ion_frag['charge'] = charge
+                                c_new_ion_frag['mz'] = ursgal.ucore.calculate_mz(new_ion_frag['mass'], charge)
+                                pos_dict['pos{0}'.format(dpos+1)][ion_type].append(c_new_ion_frag)
                         alread_seen_frags.add(_id)
         if delete_pos0:
             del pos_dict['pos0']

--- a/peptide_fragmentor/peptide_fragmentor.py
+++ b/peptide_fragmentor/peptide_fragmentor.py
@@ -21,7 +21,8 @@ class PeptideFragment0r:
                 format PEPTIDE#<UNIMOD_NAME>:<POS>;<UNIMOD_NAME>:<POS> ...
             charges (list, optional): Charges for frag ion creation, default
                 is 1, 2, 3
-            neutral_losses (list, optional): Description
+            neutral_losses (dict, optional): Dictionary that specifies lists of
+                potential neutral losses for each amino acid.
             ions (list of str): Which ions shall be calculated. Overhead is small
                 fall all ions so maybe not worth it ...
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 numpy
-pyqms
+ursgal

--- a/tests/test_peptide_fragmentor.py
+++ b/tests/test_peptide_fragmentor.py
@@ -5,25 +5,25 @@ from pandas import DataFrame
 from peptide_fragmentor import PeptideFragment0r
 
 
-def test_precursor_ion_calculated_correctly():
-    fragger = PeptideFragment0r('MK', charges=[1])
-    # no series, only precursor
-    fragments = fragger.fragment_peptide(ion_series=[])
-    assert isinstance(fragments, DataFrame)
-    assert len(fragments) == 1
-    row = fragments.iloc[0]
+# def test_precursor_ion_calculated_correctly():
+#     fragments = PeptideFragment0r('MK', charges=[1])
+#     # no series, only precursor
+#     fragments = fragger.fragment_peptide(ion_series=[])
+#     assert isinstance(fragments, DataFrame)
+#     assert len(fragments) == 1
+#     row = fragments.iloc[0]
 
 
 
 def test_fragment_two_aa_peptide_a_series():
     """Test a1 fragmentation"""
-    fragger = PeptideFragment0r('MK', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['a'])
+    fragments = PeptideFragment0r('MK', charges=[1], ions=['a']).df
+    # fragments = fragger.fragment_peptide(ion_series=['a'])
     assert isinstance(fragments, DataFrame)
     # assert len(fragments) == 2
     row = fragments.iloc[0]
     assert row['name'] == 'a1'
-    assert row['cc'] == 'C(4)H(9)N(1)S(1)'
+    assert row['hill'] == 'C(4)H(9)N(1)S(1)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
@@ -33,13 +33,13 @@ def test_fragment_two_aa_peptide_a_series():
 
 def test_fragment_three_aa_peptide_a_series():
     """Test a2 fragmentation"""
-    fragger = PeptideFragment0r('MKK', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['a'])
+    fragments = PeptideFragment0r('MKK', charges=[1], ions=['a']).df
+    # fragments = fragger.fragment_peptide(ion_series=['a'])
     assert isinstance(fragments, DataFrame)
     # assert len(fragments) == 3
-    row = fragments.iloc[1]
+    row = fragments.iloc[2]
     assert row['name'] == 'a2'
-    assert row['cc'] == 'C(10)H(21)N(3)O(1)S(1)'
+    assert row['hill'] == 'C(10)H(21)N(3)O(1)S(1)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
@@ -49,13 +49,13 @@ def test_fragment_three_aa_peptide_a_series():
 
 def test_fragment_two_aa_peptide_b_series():
     """Test b2 fragmentation"""
-    fragger = PeptideFragment0r('KK', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['b'])
+    fragments = PeptideFragment0r('KK', charges=[1], ions=['b']).df
+    # fragments = fragger.fragment_peptide(ion_series=['b'])
     assert isinstance(fragments, DataFrame)
 
-    row = fragments.iloc[1]
+    row = fragments.iloc[6]
     assert row['name'] == 'b2'
-    assert row['cc'] == 'C(12)H(24)N(4)O(2)'
+    assert row['hill'] == 'C(12)H(24)N(4)O(2)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
@@ -65,13 +65,13 @@ def test_fragment_two_aa_peptide_b_series():
 
 def test_fragment_three_aa_peptide_b_series():
     """Test b3 fragmentation"""
-    fragger = PeptideFragment0r('KKK', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['b'])
+    fragments = PeptideFragment0r('KKK', charges=[1], ions=['b']).df
+    # fragments = fragger.fragment_peptide(ion_series=['b'])
     assert isinstance(fragments, DataFrame)
     # assert len(fragments) == 3
     row = fragments.iloc[2]
     assert row['name'] == 'b3'
-    assert row['cc'] == 'C(18)H(36)N(6)O(3)'
+    assert row['hill'] == 'C(18)H(36)N(6)O(3)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
@@ -81,23 +81,23 @@ def test_fragment_three_aa_peptide_b_series():
 
 def test_fragment_three_aa_peptide_c_series():
     """Test c1/2 fragmentation"""
-    fragger = PeptideFragment0r('MKK', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['c'])
+    fragments = PeptideFragment0r('MKK', charges=[1],ions=['c']).df
+    # fragments = fragger.fragment_peptide(ion_series=['c'])
     assert isinstance(fragments, DataFrame)
     # assert len(fragments) == 3
 
     row = fragments.iloc[0]
     assert row['name'] == 'c1'
-    assert row['cc'] == 'C(5)H(12)N(2)O(1)S(1)'
+    assert row['hill'] == 'C(5)H(12)N(2)O(1)S(1)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
         5e-6
     ) == 149.07436
 
-    row = fragments.iloc[1]
+    row = fragments.iloc[2]
     assert row['name'] == 'c2'
-    assert row['cc'] == 'C(11)H(24)N(4)O(2)S(1)'
+    assert row['hill'] == 'C(11)H(24)N(4)O(2)S(1)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
@@ -107,14 +107,14 @@ def test_fragment_three_aa_peptide_c_series():
 
 def test_fragment_three_aa_peptide_x_series():
     """Test x2 fragmentation"""
-    fragger = PeptideFragment0r('MKK', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['x'])
+    fragments = PeptideFragment0r('MKK', charges=[1], ions=['x']).df
+    # fragments = fragger.fragment_peptide(ion_series=['x'])
     assert isinstance(fragments, DataFrame)
     # assert len(fragments) == 3
 
-    row = fragments.iloc[1]
+    row = fragments.iloc[3]
     assert row['name'] == 'x2'
-    assert row['cc'] == 'C(13)H(24)N(4)O(4)'
+    assert row['hill'] == 'C(13)H(24)N(4)O(4)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
@@ -124,14 +124,14 @@ def test_fragment_three_aa_peptide_x_series():
 
 def test_fragment_one_aa_peptide_y_series():
     """Test y1 fragmentation"""
-    fragger = PeptideFragment0r('K', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['y'])
+    fragments = PeptideFragment0r('K', charges=[1], ions=['y']).df
+    # fragments = fragger.fragment_peptide(ion_series=['y'])
     assert isinstance(fragments, DataFrame)
     # assert len(fragments) == 1
 
-    row = fragments.iloc[0]
+    row = fragments.iloc[1]
     assert row['name'] == 'y1'
-    assert row['cc'] == 'C(6)H(14)N(2)O(2)'
+    assert row['hill'] == 'C(6)H(14)N(2)O(2)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
@@ -141,14 +141,14 @@ def test_fragment_one_aa_peptide_y_series():
 
 def test_fragment_two_aa_peptide_y_series():
     """Test y2 fragmentation"""
-    fragger = PeptideFragment0r('KK', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['y'])
+    fragments = PeptideFragment0r('KK', charges=[1], ions=['y']).df
+    # fragments = fragger.fragment_peptide(ion_series=['y'])
     assert isinstance(fragments, DataFrame)
     # assert len(fragments) == 2
 
-    row = fragments.iloc[1]
+    row = fragments.iloc[3]
     assert row['name'] == 'y2'
-    assert row['cc'] == 'C(12)H(26)N(4)O(3)'
+    assert row['hill'] == 'C(12)H(26)N(4)O(3)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
@@ -158,12 +158,12 @@ def test_fragment_two_aa_peptide_y_series():
 
 def test_fragment_three_aa_peptide_z_series():
     """Test z2 fragmentation"""
-    fragger = PeptideFragment0r('MKK', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['z'])
+    fragments = PeptideFragment0r('MKK', charges=[1], ions=['z']).df
+    # fragments = fragger.fragment_peptide(ion_series=['z'])
     assert isinstance(fragments, DataFrame)
     # assert len(fragments) == 3
 
-    row = fragments.iloc[1]
+    row = fragments.iloc[2]
     assert row['name'] == 'z2'
     # assert row['cc'] == 'C(11)H(24)N(4)O(2)S(1)'
     assert row['charge'] == 1
@@ -174,15 +174,15 @@ def test_fragment_three_aa_peptide_z_series():
 
 
 def test_fragment_two_aa_peptide_b_series_with_mod():
-    """Test y2 fragmentation"""
-    fragger = PeptideFragment0r('MKK#Oxidation:1', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['b'])
+    """Test b2 fragmentation with unimod"""
+    fragments = PeptideFragment0r('MKK#Oxidation:1', charges=[1], ions=['b']).df
+    # fragments = fragger.fragment_peptide(ion_series=['b'])
     assert isinstance(fragments, DataFrame)
     # assert len(fragments) == 3
 
-    row = fragments.iloc[1]
+    row = fragments.iloc[7]
     assert row['name'] == 'b2'
-    assert row['cc'] == 'C(11)H(21)N(3)O(3)S(1)'
+    assert row['hill'] == 'C(11)H(21)N(3)O(3)S(1)'
     assert row['charge'] == 1
     assert pytest.approx(
         row['mz'],
@@ -191,8 +191,8 @@ def test_fragment_two_aa_peptide_b_series_with_mod():
 
 
 def test_fragment_one_aa_peptide_internal():
-    fragger = PeptideFragment0r('RKKR', charges=[1])
-    fragments = fragger.fragment_peptide(ion_series=['internal b-y'])
+    fragments = PeptideFragment0r('RKKR', charges=[1], ions=['I']).df
+    # fragments = fragger.fragment_peptide(ion_series=['internal b-y'])
     assert isinstance(fragments, DataFrame)
     print(fragments)
 


### PR DESCRIPTION
- charges != 1 are included now
- using ursgal.ChemicalComposition instead of pyqms
- neutral_losses specified as dict instead of list
- removing duplicated ions from added and removed neutral losses (e.g. y5 -H2O, +H2O)
- started fixing tests